### PR TITLE
Add a missing comma to the synopsis example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SYNOPSIS
 
     use Getopt::Long;
     get-options("length=i" => my $length, # numeric
-                "file=s"   => my $file    # string
+                "file=s"   => my $file,   # string
                 "verbose"  => my $verbose); # flag
 
 or


### PR DESCRIPTION
Hi,

Thanks for your work on Getopt::Long, and for all your Perl and Raku work in general!

What do you think about the attached trivial patch?

G'luck,
Peter
