### PR TITLE
Apparently, CORE::Exception didn't exist in 2019.07

### DIFF
--- a/lib/Getopt/Long.pm
+++ b/lib/Getopt/Long.pm
@@ -3,7 +3,7 @@ use fatal;
 
 unit class Getopt::Long:ver<0.1.6>;
 
-role Exceptional is CORE::Exception {
+role Exceptional is Exception {
 }
 
 class Exception does Exceptional {


### PR DESCRIPTION
and its corresponding point release. This has been tested for 2020.05 as well as 2019.07, and it works. Closes #8 when accepted.